### PR TITLE
Time should be 64bit

### DIFF
--- a/bitvavo.go
+++ b/bitvavo.go
@@ -27,7 +27,7 @@ type TimeResponse struct {
 }
 
 type Time struct {
-  Time int `json:"time"`
+  Time int64 `json:"time,string"`
 }
 
 type MarketsResponse struct {


### PR DESCRIPTION
- JSON parse to struct fails because the number returned is to big for an int.
json: cannot unmarshal number 1609938804312 into Go struct field Time.time of type int