### PR TITLE
Non blocking subscription channels & unsubscribe functionality

### DIFF
--- a/bitvavo.go
+++ b/bitvavo.go
@@ -1883,3 +1883,52 @@ func (ws *Websocket) SubscriptionBook(market string, options map[string]string) 
   ws.conn.WriteMessage(websocket.TextMessage, []byte(mySecondMessage))
   return ws.subscriptionBookChannelMap[market]
 }
+
+func (ws *Websocket) UnsubscribeTicker(market string) {
+    delete(ws.subscriptionTickerOptionsMap, market)
+    options := SubscriptionTickerObject{Action: "unsubscribe", Channels: []SubscriptionTickAccSubObject{SubscriptionTickAccSubObject{Name: "ticker", Markets: []string{market}}}}
+    myMessage, _ := json.Marshal(options)
+    ws.conn.WriteMessage(websocket.TextMessage, []byte(myMessage))
+}
+
+func (ws *Websocket) UnsubscribeTicker24h(market string) {
+    delete(ws.subscriptionTicker24hOptionsMap, market)
+    options := SubscriptionTickerObject{Action: "unsubscribe", Channels: []SubscriptionTickAccSubObject{SubscriptionTickAccSubObject{Name: "ticker24h", Markets: []string{market}}}}
+    myMessage, _ := json.Marshal(options)
+    ws.conn.WriteMessage(websocket.TextMessage, []byte(myMessage))
+}
+
+func (ws *Websocket) UnsubscribeAccount(market string) {
+    delete(ws.subscriptionAccountOptionsMap, market)
+    options := SubscriptionTickerObject{Action: "unsubscribe", Channels: []SubscriptionTickAccSubObject{SubscriptionTickAccSubObject{Name: "account", Markets: []string{market}}}}
+    myMessage, _ := json.Marshal(options)
+    ws.conn.WriteMessage(websocket.TextMessage, []byte(myMessage))
+}
+
+func (ws *Websocket) UnsubscribeCandles(market string, interval string) {
+    delete(ws.subscriptionCandlesOptionsMap, market)
+    options := SubscriptionCandlesObject{Action: "unsubscribe", Channels: []SubscriptionCandlesSubObject{SubscriptionCandlesSubObject{Name: "candles", Interval: []string{interval}, Markets: []string{market}}}}
+    myMessage, _ := json.Marshal(options)
+    ws.conn.WriteMessage(websocket.TextMessage, []byte(myMessage))
+}
+
+func (ws *Websocket) UnsubscribeTrades(market string) {
+    delete(ws.subscriptionTradesOptionsMap, market)
+    options := SubscriptionTradesBookObject{Action: "unsubscribe", Channels: []SubscriptionTradesBookSubObject{SubscriptionTradesBookSubObject{Name: "trades", Markets: []string{market}}}}
+    myMessage, _ := json.Marshal(options)
+    ws.conn.WriteMessage(websocket.TextMessage, []byte(myMessage))
+}
+
+func (ws *Websocket) UnsubscribeBookUpdate(market string) {
+    delete(ws.subscriptionBookUpdateOptionsMap, market)
+    options := SubscriptionTradesBookObject{Action: "unsubscribe", Channels: []SubscriptionTradesBookSubObject{SubscriptionTradesBookSubObject{Name: "book", Markets: []string{market}}}}
+    myMessage, _ := json.Marshal(options)
+    ws.conn.WriteMessage(websocket.TextMessage, []byte(myMessage))
+}
+
+func (ws *Websocket) UnsubscribeBook(market string) {
+    delete(ws.subscriptionBookOptionsSecondMap, market)
+    options := SubscriptionTradesBookObject{Action: "unsubscribe", Channels: []SubscriptionTradesBookSubObject{SubscriptionTradesBookSubObject{Name: "book", Markets: []string{market}}}}
+    myMessage, _ := json.Marshal(options)
+    ws.conn.WriteMessage(websocket.TextMessage, []byte(myMessage))
+}


### PR DESCRIPTION
Related to Issue #5 

## Problem
The current mechanism of pushing the WebSocket responses to subscription channels is prone to blocking.
For example, if one subscribes to the Ticker for multiple markets but does not consume all the ticker events from all channels (eg. at some point you are no longer interested in a specific ticker and you stop reading from its channel) then the whole `handleMessage` function will block at the point where the specific channel has reached maximum capacity (100) and cannot push any more messages. This will prevent further consumption of WebSocket responses as well.

## Solution
This PR addresses the above with the bare minimum effort. I have restrained from doing any further code improvements (including modularization, formatting, or addressing issues in other parts) in hope that this can be a small change that can be reviewed and accepted quickly. The approach is simple:

- Move the event handling code into its own method for easier refactoring
- Convert the parts where a message is sent to the subscription channel into a  `select{}` with a `default` case so the operation becomes non-blocking
- Add basic Unsubscribe methods for every Subscription method (supported by the API but were not implemented in this client)

## What this PR does not address
- Draining the channels that have been unsubscribed
- Possible block in the `addTooBook` function
