### PR TITLE
Fix: Prevent panic on client request error by returning early

### DIFF
--- a/bitvavo.go
+++ b/bitvavo.go
@@ -630,6 +630,7 @@ func (bitvavo Bitvavo) sendPrivate(endpoint string, postfix string, body map[str
   resp, err := client.Do(req)
   if err != nil {
     errorToConsole("We caught an error " + err.Error())
+    return nil
   }
   defer resp.Body.Close()
   respBody, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
This lib can cause panics if an error occurs during the HTTP request because the response body (resp.Body) is accessed even when resp is nil.

Changes in PR:

Added a return nil after logging the error to prevent further execution when err is not nil.
Ensured the application gracefully handles the error instead of panicking.

